### PR TITLE
Added an update option to the command line

### DIFF
--- a/Q_Builder.sh
+++ b/Q_Builder.sh
@@ -356,7 +356,7 @@ ZIP_FILE=$(ls -rt ${BUILDBASE}/android/lineage/out/target/product/$OUTPUTFILE/li
 ## Copy to output
 echo "Creating switchroot install dir..."
 mkdir -p $BUILDBASE/android/output/switchroot/install
-if [$UPDATE = false]; then
+if [-z $UPDATE]; then
 	echo "Creating switchroot android dir..."
 	mkdir -p $BUILDBASE/android/output/switchroot/android
 fi
@@ -379,7 +379,7 @@ echo "Copying build combined kernel and ramdisk..."
 cp $BUILDBASE/android/lineage/out/target/product/$OUTPUTFILE/boot.img $BUILDBASE/android/output/switchroot/install/
 echo "Copying build dtb..."
 cp $BUILDBASE/android/lineage/out/target/product/$OUTPUTFILE/obj/KERNEL_OBJ/arch/arm64/boot/dts/tegra210-icosa.dtb $BUILDBASE/android/output/switchroot/install/
-if [$UPDATE = false]; then
+if [-z $UPDATE]; then
 	echo "Downloading twrp..."
 	curl -L -o $BUILDBASE/android/output/switchroot/install/twrp.img https://github.com/PabloZaiden/switchroot-android-build/raw/master/external/twrp.img
 	echo "Downloading coreboot.rom..."

--- a/Q_Builder.sh
+++ b/Q_Builder.sh
@@ -31,6 +31,16 @@ do
 		fi
 		CLEAN=true
     fi
+    	if ["$arg" == "--update"] || ["$arg" == "-u"];
+    then
+    	echo "Update mode enabled."
+		if [$CLEAN]
+		then
+			echo "Clean and Update modes are incompatible..assuming Update."
+			CLEAN=false
+		fi
+		UPDATE=true
+    fi
 	if [ "$arg" == "--noccache" ] || [ "$arg" == "-e" ];
     then
         echo "CCache disabled."
@@ -44,6 +54,7 @@ do
 		printf -- "-v | --verbose\t\tActivates verbose mode\n"
 		printf -- "-n | --nosync\t\tDisables repo syncing and git cleaning and just forces a direct rebuild\n"
 		printf -- "-c | --clean\t\tForces a clean build--deletes BUILDBASE/android and redownloads sources\n"
+		printf -- "-u | --update\t\tForces an update build--only keeps the boot.img, DTB file, and LineageOS flashable zip\n"
 		printf -- "-e | --noccache\t\tNOT RECOMMENDED--disables using CCache for building, which reduces storage consumption but can have unintended consequences\n\n"
 		printf "MORE INFO:\n\nExport the BUILDBASE environment variable as the directory you want to build in\nEXAMPLE: export BUILDBASE=/home/tmakin\n"
 		printf "WSL2 users should note that NTFS sucks and ext4 is recommended, and mounting an external NTFS drive is supported in newer Insider Dev Channel builds\nFor more info, see https://docs.microsoft.com/en-us/windows/wsl/wsl2-mount-disk\n\n"
@@ -350,8 +361,10 @@ ZIP_FILE=$(ls -rt ${BUILDBASE}/android/lineage/out/target/product/$OUTPUTFILE/li
 ## Copy to output
 echo "Creating switchroot install dir..."
 mkdir -p $BUILDBASE/android/output/switchroot/install
-echo "Creating switchroot android dir..."
-mkdir -p $BUILDBASE/android/output/switchroot/android
+if [$UPDATE = false]; then
+	echo "Creating switchroot android dir..."
+	mkdir -p $BUILDBASE/android/output/switchroot/android
+fi
 
 if [ $HEKATE = "y" ];
 	then
@@ -371,9 +384,11 @@ echo "Copying build combined kernel and ramdisk..."
 cp $BUILDBASE/android/lineage/out/target/product/$OUTPUTFILE/boot.img $BUILDBASE/android/output/switchroot/install/
 echo "Copying build dtb..."
 cp $BUILDBASE/android/lineage/out/target/product/$OUTPUTFILE/obj/KERNEL_OBJ/arch/arm64/boot/dts/tegra210-icosa.dtb $BUILDBASE/android/output/switchroot/install/
-echo "Downloading twrp..."
-curl -L -o $BUILDBASE/android/output/switchroot/install/twrp.img https://github.com/PabloZaiden/switchroot-android-build/raw/master/external/twrp.img
-echo "Downloading coreboot.rom..."
+if [$UPDATE = false]; then
+	echo "Downloading twrp..."
+	curl -L -o $BUILDBASE/android/output/switchroot/install/twrp.img https://github.com/PabloZaiden/switchroot-android-build/raw/master/external/twrp.img
+	echo "Downloading coreboot.rom..."
+fi
 
 # oc coreboot check
 if [ $MEMOC = "y" ];
@@ -384,9 +399,11 @@ else
 	curl -L -o $BUILDBASE/android/output/switchroot/android/coreboot.rom https://github.com/PabloZaiden/switchroot-android-build/raw/5591127dc4b9ef3ed1afb0bb677d05108705caa5/external/coreboot.rom
 fi
 
-echo "Downloading boot scripts..."
-curl -L -o $BUILDBASE/android/output/switchroot/android/common.scr https://gitlab.com/switchroot/bootstack/switch-uboot-scripts/-/jobs/artifacts/master/raw/common.scr?job=build
-curl -L -o $BUILDBASE/android/output/switchroot/android/boot.scr https://gitlab.com/switchroot/bootstack/switch-uboot-scripts/-/jobs/artifacts/master/raw/sd.scr?job=build
+if [$UPDATE = false]; then
+	echo "Downloading boot scripts..."
+	curl -L -o $BUILDBASE/android/output/switchroot/android/common.scr https://gitlab.com/switchroot/bootstack/switch-uboot-scripts/-/jobs/artifacts/master/raw/common.scr?job=build
+	curl -L -o $BUILDBASE/android/output/switchroot/android/boot.scr https://gitlab.com/switchroot/bootstack/switch-uboot-scripts/-/jobs/artifacts/master/raw/sd.scr?job=build
+fi
 
 if [ $GAPPS = "y" ];
 then

--- a/Q_Builder.sh
+++ b/Q_Builder.sh
@@ -388,16 +388,17 @@ if [$UPDATE = false]; then
 	echo "Downloading twrp..."
 	curl -L -o $BUILDBASE/android/output/switchroot/install/twrp.img https://github.com/PabloZaiden/switchroot-android-build/raw/master/external/twrp.img
 	echo "Downloading coreboot.rom..."
+	# oc coreboot check
+	if [ $MEMOC = "y" ];
+	then
+		curl -L -o $BUILDBASE/android/output/switchroot/android/coreboot.rom https://github.com/PabloZaiden/switchroot-android-build/raw/5591127dc4b9ef3ed1afb0bb677d05108705caa5/external/coreboot-oc.rom
+		zip -u $BUILDBASE/android/output/switchroot/android/coreboot.rom $OUTPUT_ZIP_FILE firmware-update/coreboot.rom
+	else
+		curl -L -o $BUILDBASE/android/output/switchroot/android/coreboot.rom https://github.com/PabloZaiden/switchroot-android-build/raw/5591127dc4b9ef3ed1afb0bb677d05108705caa5/external/coreboot.rom
+	fi
 fi
 
-# oc coreboot check
-if [ $MEMOC = "y" ];
-then
-	curl -L -o $BUILDBASE/android/output/switchroot/android/coreboot.rom https://github.com/PabloZaiden/switchroot-android-build/raw/5591127dc4b9ef3ed1afb0bb677d05108705caa5/external/coreboot-oc.rom
-	zip -u $BUILDBASE/android/output/switchroot/android/coreboot.rom $OUTPUT_ZIP_FILE firmware-update/coreboot.rom
-else
-	curl -L -o $BUILDBASE/android/output/switchroot/android/coreboot.rom https://github.com/PabloZaiden/switchroot-android-build/raw/5591127dc4b9ef3ed1afb0bb677d05108705caa5/external/coreboot.rom
-fi
+
 
 if [$UPDATE = false]; then
 	echo "Downloading boot scripts..."

--- a/Q_Builder.sh
+++ b/Q_Builder.sh
@@ -34,11 +34,6 @@ do
     	if ["$arg" == "--update"] || ["$arg" == "-u"];
     then
     	echo "Update mode enabled."
-		if [$CLEAN]
-		then
-			echo "Clean and Update modes are incompatible..assuming Update."
-			CLEAN=false
-		fi
 		UPDATE=true
     fi
 	if [ "$arg" == "--noccache" ] || [ "$arg" == "-e" ];

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ OC patch (CPU)
 
 Joycon patch (snapshot button takes screenshots)
 
-GApps download
+GApps and Hekate download
 
 Option to preroot with magisk
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Syntax: `./Q_Builder.sh [-v | --verbose] [-n | --nosync] [-c | --clean]`
 - `-v | --verbose`: Enables verbose mode (`set -x`) for debugging
 - `-n | --nosync`: Runs build without `git reset` or `repo sync` (keeps source tree from last build intact)
 - `-c | --clean`: Forces clean build (removes source tree and builds from scratch)
+- `-u | --update`: Sets up the build for a dirty flash by preventing the download of twrp.img, and all files in switchroot/android folder
 - `-e | --noccache`: Disables CCache for building (NOT RECOMMENDED--MOSTLY FOR TESTING PURPOSES)
 - `-h | --help`: Long-winded help message
 


### PR DESCRIPTION
The update option only copies necessary files for a dirty update. This means it only copies the boot.img, DTB file, and the LineageOS flashable zip.