### PR TITLE
Fix and Improvements

### DIFF
--- a/Q_Builder.sh
+++ b/Q_Builder.sh
@@ -65,14 +65,14 @@ do
     fi
 done
 
-# backup files based on patch file. usage e.g.) backup_original joycond10.patch
+# backup files based on patch file. usage e.g.) backup_original /location/to/patch/patchname.patch
 backup_original() {
 	for UNPATCHEDFILES in $(cat $1 | grep -o -P '(?<=diff --git a/).*(?= b/)') ; do
     	cp $UNPATCHEDFILES $UNPATCHEDFILES.bak
 	done
 }
 
-# restore backuped files based on patch file. usage e.g.) restore_original joycond10.patch
+# restore backuped files based on patch file. usage e.g.) restore_original /location/to/patch/patchname.patch
 restore_original() {
 	for PATCHEDFILES in $(cat $1 | grep -o -P '(?<=diff --git a/).*(?= b/)') ; do
     	[ -f $(echo $PATCHEDFILES).bak ] && rm -Rf $PATCHEDFILES && mv $PATCHEDFILES.bak $PATCHEDFILES
@@ -211,13 +211,13 @@ fi
 if [ -z $CLEAN ] && [ -d $BUILDBASE/android ] ; then
 	# restore backuped files
     cd $BUILDBASE/android/lineage/kernel/nvidia/linux-4.9/kernel/kernel-4.9
-	restore_original oc-android10.patch
+	restore_original $CWD/patches/oc-android10.patch
 
     cd $BUILDBASE/android/lineage/device/nvidia/foster
-	restore_original oc_profiles.patch
+	restore_original $CWD/patches/oc_profiles.patch
 
     cd $BUILDBASE/android/lineage/hardware/nintendo/joycond
-	restore_original joycond10.patch
+	restore_original $CWD/patches/joycond10.patch
 
     cd $BUILDBASE
 fi


### PR DESCRIPTION
Fix:
Fix file locations when using restore function

Add:
add apply_custom_patch function to reduce repetitive text

Change:
change WSL detection method based on microsoft/WSL#4555 (comment)
detect WSL after "get current working directory"
make backup and restore (based on patch file) as separate function for easier use. behind is usage example.
> # Backup
> cd $BUILDBASE/android/lineage/hardware/nintendo/joycond
> backup_original $CWD/patches/joycond10.patch
>
> # Restore
> cd $BUILDBASE/android/lineage/hardware/nintendo/joycond
> restore_original $CWD/patches/joycond10.patch