### PR TITLE
Ask the user for the Buildbase folder instead of forcing them to export the variable with their Buildbase folder

### DIFF
--- a/Q_Builder.sh
+++ b/Q_Builder.sh
@@ -2,10 +2,6 @@
 
 # get current working directory
 CWD=$(pwd)
-if [ -z "$BUILDBASE" ];
-then
-	BUILDBASE=~
-fi
 
 # arguments
 for arg in "$@"
@@ -31,7 +27,7 @@ do
 		fi
 		CLEAN=true
     fi
-    	if ["$arg" == "--update"] || ["$arg" == "-u"];
+    	if [ "$arg" == "--update" ] || [ "$arg" == "-u" ];
     then
     	echo "Update mode enabled."
 		UPDATE=true
@@ -51,13 +47,17 @@ do
 		printf -- "-c | --clean\t\tForces a clean build--deletes BUILDBASE/android and redownloads sources\n"
 		printf -- "-u | --update\t\tForces an update build--only keeps the boot.img, DTB file, and LineageOS flashable zip\n"
 		printf -- "-e | --noccache\t\tNOT RECOMMENDED--disables using CCache for building, which reduces storage consumption but can have unintended consequences\n\n"
-		printf "MORE INFO:\n\nExport the BUILDBASE environment variable as the directory you want to build in\nEXAMPLE: export BUILDBASE=/home/tmakin\n"
-		printf "WSL2 users should note that NTFS sucks and ext4 is recommended, and mounting an external NTFS drive is supported in newer Insider Dev Channel builds\nFor more info, see https://docs.microsoft.com/en-us/windows/wsl/wsl2-mount-disk\n\n"
+		printf "MORE INFO:\n\nWSL2 users should note that NTFS sucks and ext4 is recommended, and mounting an external NTFS drive is supported in newer Insider Dev Channel builds\nFor more info, see https://docs.microsoft.com/en-us/windows/wsl/wsl2-mount-disk\n\n"
 		
 		# force exit on fail
 		exit -1
     fi
 done
+
+if [ -z "$BUILDBASE" ];
+then
+	read -p "Enter the parent folder where the android folder is in: " BUILDBASE
+fi
 
 cd $BUILDBASE
 

--- a/Q_Builder.sh
+++ b/Q_Builder.sh
@@ -95,6 +95,7 @@ apply_patches() {
 	done
 }
 
+# Code below suggested by someone5678
 read -p "Enter the location where android buildbase will be located ex: ~/Downloads
 (Just press enter if you wanna use default location): " BUILDBASE
 if [ -z $BUILDBASE ] ; then

--- a/Q_Builder.sh
+++ b/Q_Builder.sh
@@ -379,6 +379,7 @@ echo "Copying build combined kernel and ramdisk..."
 cp $BUILDBASE/android/lineage/out/target/product/$OUTPUTFILE/boot.img $BUILDBASE/android/output/switchroot/install/
 echo "Copying build dtb..."
 cp $BUILDBASE/android/lineage/out/target/product/$OUTPUTFILE/obj/KERNEL_OBJ/arch/arm64/boot/dts/tegra210-icosa.dtb $BUILDBASE/android/output/switchroot/install/
+
 if [ -z $UPDATE ]; then
 	echo "Downloading twrp..."
 	curl -L -o $BUILDBASE/android/output/switchroot/install/twrp.img https://github.com/PabloZaiden/switchroot-android-build/raw/master/external/twrp.img

--- a/Q_Builder.sh
+++ b/Q_Builder.sh
@@ -95,10 +95,12 @@ apply_patches() {
 	done
 }
 
-if [ -z "$BUILDBASE" ];
-then
-	read -p "Enter the parent folder where the android folder is in: " BUILDBASE
+read -p "Enter the location where android buildbase will be located ex: ~/Downloads
+(Just press enter if you wanna use default location): " BUILDBASE
+if [ -z $BUILDBASE ] ; then
+	BUILDBASE=~
 fi
+echo "Buildbase set to $BUILDBASE"
 
 cd $BUILDBASE
 

--- a/Q_Builder.sh
+++ b/Q_Builder.sh
@@ -47,7 +47,7 @@ do
 		printf -- "-c | --clean\t\tForces a clean build--deletes BUILDBASE/android and redownloads sources\n"
 		printf -- "-u | --update\t\tForces an update build--only keeps the boot.img, DTB file, and LineageOS flashable zip\n"
 		printf -- "-e | --noccache\t\tNOT RECOMMENDED--disables using CCache for building, which reduces storage consumption but can have unintended consequences\n\n"
-		printf "MORE INFO:\n\nWSL2 users should note that NTFS sucks and ext4 is recommended, and mounting an external NTFS drive is supported in newer Insider Dev Channel builds\nFor more info, see https://docs.microsoft.com/en-us/windows/wsl/wsl2-mount-disk\n\n"
+		printf "MORE INFO:\n\nWSL2 users should note that NTFS doesn't work well and ext4 is recommended, and mounting an external NTFS drive is supported in newer Insider Dev Channel builds\nFor more info, see https://docs.microsoft.com/en-us/windows/wsl/wsl2-mount-disk\n\n"
 		
 		# force exit on fail
 		exit -1

--- a/Q_Builder.sh
+++ b/Q_Builder.sh
@@ -27,7 +27,7 @@ do
 		fi
 		CLEAN=true
     fi
-    	if [ "$arg" == "--update" ] || [ "$arg" == "-u" ];
+    if [ "$arg" == "--update" ] || [ "$arg" == "-u" ];
     then
     	echo "Update mode enabled."
 		UPDATE=true

--- a/Q_Builder.sh
+++ b/Q_Builder.sh
@@ -27,7 +27,7 @@ do
 		fi
 		CLEAN=true
     fi
-    if [ "$arg" == "--update" ] || [ "$arg" == "-u" ];
+  	if [ "$arg" == "--update" ] || [ "$arg" == "-u" ];
     then
     	echo "Update mode enabled."
 		UPDATE=true

--- a/Q_Builder.sh
+++ b/Q_Builder.sh
@@ -379,7 +379,7 @@ echo "Copying build combined kernel and ramdisk..."
 cp $BUILDBASE/android/lineage/out/target/product/$OUTPUTFILE/boot.img $BUILDBASE/android/output/switchroot/install/
 echo "Copying build dtb..."
 cp $BUILDBASE/android/lineage/out/target/product/$OUTPUTFILE/obj/KERNEL_OBJ/arch/arm64/boot/dts/tegra210-icosa.dtb $BUILDBASE/android/output/switchroot/install/
-if [-z $UPDATE]; then
+if [ -z $UPDATE ]; then
 	echo "Downloading twrp..."
 	curl -L -o $BUILDBASE/android/output/switchroot/install/twrp.img https://github.com/PabloZaiden/switchroot-android-build/raw/master/external/twrp.img
 	echo "Downloading coreboot.rom..."
@@ -395,7 +395,7 @@ fi
 
 
 
-if [$UPDATE = false]; then
+if [ -z $UPDATE ]; then
 	echo "Downloading boot scripts..."
 	curl -L -o $BUILDBASE/android/output/switchroot/android/common.scr https://gitlab.com/switchroot/bootstack/switch-uboot-scripts/-/jobs/artifacts/master/raw/common.scr?job=build
 	curl -L -o $BUILDBASE/android/output/switchroot/android/boot.scr https://gitlab.com/switchroot/bootstack/switch-uboot-scripts/-/jobs/artifacts/master/raw/sd.scr?job=build

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Decent CPU (better CPU --> faster build)
 Unpatched Erista-codenamed Nintendo Switch (https://ismyswitchpatched.com/) with RCM jig to trigger exploit
 
 # Building
-Syntax: `./Q_Builder.sh [-v | --verbose] [-n | --nosync] [-c | --clean]`
+Syntax: `./Q_Builder.sh [-v | --verbose] [-n | --nosync] [-c | --clean] [-u | --update]`
 
 - `-v | --verbose`: Enables verbose mode (`set -x`) for debugging
 - `-n | --nosync`: Runs build without `git reset` or `repo sync` (keeps source tree from last build intact)


### PR DESCRIPTION
As said in the title, it removes having to do `export BUILDBASE=/home/emre/` and just asks for this at startup.
